### PR TITLE
Fix incorrect use of the static keyword.

### DIFF
--- a/SFEMP3Shield/SFEMP3Shield.cpp
+++ b/SFEMP3Shield/SFEMP3Shield.cpp
@@ -21,6 +21,15 @@ PROGMEM prog_uint16_t bitrate_table[14][6] = { {0,0,0,0,0,0},
 					       {384,256,224,192,128,128}, //1100
 					       {416,320,256,224,144,144} };//1101
 
+Sd2Card card;
+SdVolume volume;
+SdFile root;
+SdFile track;
+uint8_t playing;
+
+//buffer for music
+uint8_t mp3DataBuffer[32];
+
 //Inits everything
 uint8_t SFEMP3Shield::begin(){
 

--- a/SFEMP3Shield/SFEMP3Shield.h
+++ b/SFEMP3Shield/SFEMP3Shield.h
@@ -48,14 +48,14 @@ void Mp3WriteRegister(uint8_t, uint8_t, uint8_t);
 uint16_t Mp3ReadRegister (uint8_t);
 
 //Create the variables to be used by SdFat Library
-static Sd2Card card;
-static SdVolume volume;
-static SdFile root;
-static SdFile track;
-static uint8_t playing;
+extern Sd2Card card;
+extern SdVolume volume;
+extern SdFile root;
+extern SdFile track;
+extern uint8_t playing;
 
 //buffer for music
-static uint8_t mp3DataBuffer[32];
+extern uint8_t mp3DataBuffer[32];
 
 //MP3 Player Shield pin mapping. See the schematic
 #define MP3_XCS 6 //Control Chip Select Pin (for accessing SPI Control/Status registers)


### PR DESCRIPTION
Various globals provided by the SFEMP3Shield library were declared as static
in the header file.  This caused them to be re-instantiated in each
source file which included them.  The result was that from the
perspective of the sketch, these globals were all uninitialized and
did not work when used.

This patch corrects the globals to be declared extern in the header
file, and unadorned in the library source file.  This is standard
practice when exposing global variables in a library.
