### PR TITLE
Added optional timecode delayed start to ::playTrack just as in ::playMP3

### DIFF
--- a/SFEMP3Shield/SFEMP3Shield.cpp
+++ b/SFEMP3Shield/SFEMP3Shield.cpp
@@ -1022,7 +1022,7 @@ void SFEMP3Shield::setMonoMode(uint16_t StereoMode) {
  * \see
  * \ref Error_Codes
  */
-uint8_t SFEMP3Shield::playTrack(uint8_t trackNo){
+uint8_t SFEMP3Shield::playTrack(uint8_t trackNo, uint32_t timecode){
 
   //a storage place for track names
   char trackName[] = "track001.mp3";
@@ -1032,7 +1032,7 @@ uint8_t SFEMP3Shield::playTrack(uint8_t trackNo){
   sprintf(trackName, "track%03d.mp3", trackNo);
 
   //play the file
-  return playMP3(trackName);
+  return playMP3(trackName, timecode);
 }
 
 //------------------------------------------------------------------------------

--- a/SFEMP3Shield/SFEMP3Shield.h
+++ b/SFEMP3Shield/SFEMP3Shield.h
@@ -689,7 +689,7 @@ class SFEMP3Shield {
     void setMonoMode(uint16_t );
     void setDifferentialOutput(uint16_t);
     uint8_t getDifferentialOutput();
-    uint8_t playTrack(uint8_t);
+    uint8_t playTrack(uint8_t, uint32_t timecode = 0);
     uint8_t playMP3(char*, uint32_t timecode = 0);
     void trackTitle(char*);
     void trackArtist(char*);


### PR DESCRIPTION
Simple addition - playMP3 allowed optional timecode starting, playTrack did not. Added this in. Tested calling ::playTrack(filename), ::playTrack(filename, 0) and playTrack(filename, 2000). All results were as expected.

This is based on a customer suggestion / request.
