### PR TITLE
explicitly cast string const to char* 

### DIFF
--- a/SFEMP3Shield/SFEMP3Shield.cpp
+++ b/SFEMP3Shield/SFEMP3Shield.cpp
@@ -289,7 +289,7 @@ uint8_t SFEMP3Shield::vs_init() {
   // But the SCI_VOL register space is not in the VSdsp's WRAM space.
   // Note to keep an eye on it for future patches.
 
-  if(VSLoadUserCode("patches.053")) return 6;
+  if(VSLoadUserCode((char*)"patches.053")) return 6;
 
   delay(100); // just a good idea to let settle.
 


### PR DESCRIPTION
to avoid Arduino 1.6.8 displaying a warning compiling SFEMP3Shield.cpp on Windows
