### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/SFEMP3Shield/keywords.txt
+++ b/SFEMP3Shield/keywords.txt
@@ -6,60 +6,60 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SFEMP3Shield             KEYWORD1
+SFEMP3Shield	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-ADMixerLoad              KEYWORD2
-ADMixerVol               KEYWORD2
-available                KEYWORD2
-begin                    KEYWORD2
-end                      KEYWORD2
-currentPosition          KEYWORD2
-disableTestSineWave      KEYWORD2
-enableTestSineWave       KEYWORD2
-getAudioInfo             KEYWORD2
-getBassAmplitude         KEYWORD2
-getBassFrequency         KEYWORD2
-getEarSpeaker            KEYWORD2
-getMonoMode              KEYWORD2
-getDifferentialOutput    KEYWORD2
-getPlaySpeed             KEYWORD2
-getState                 KEYWORD2
-getTrebleAmplitude       KEYWORD2
-getTrebleFrequency       KEYWORD2
-getVolume                KEYWORD2
-getVUlevel               KEYWORD2
-getVUmeter               KEYWORD2
-isFnMusic                KEYWORD2
-isPlaying                KEYWORD2
-memoryTest               KEYWORD2
-pauseDataStream          KEYWORD2
-pauseMusic               KEYWORD2
-playMP3                  KEYWORD2
-playTrack                KEYWORD2
-resumeDataStream         KEYWORD2
-resumeMusic              KEYWORD2
-SendSingleMIDInote       KEYWORD2
-setBassAmplitude         KEYWORD2
-setBassFrequency         KEYWORD2
-setBitRate               KEYWORD2
-setEarSpeaker            KEYWORD2
-setMonoMode              KEYWORD2
-setDifferentialOutput    KEYWORD2
-setPlaySpeed             KEYWORD2
-setTrebleAmplitude       KEYWORD2
-setTrebleFrequency       KEYWORD2
-setVolume                KEYWORD2
-setVUmeter               KEYWORD2
-skip                     KEYWORD2
-skipTo                   KEYWORD2
-stopTrack                KEYWORD2
-trackAlbum               KEYWORD2
-trackArtist              KEYWORD2
-trackTitle               KEYWORD2
-vs_init                  KEYWORD2
+ADMixerLoad	KEYWORD2
+ADMixerVol	KEYWORD2
+available	KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+currentPosition	KEYWORD2
+disableTestSineWave	KEYWORD2
+enableTestSineWave	KEYWORD2
+getAudioInfo	KEYWORD2
+getBassAmplitude	KEYWORD2
+getBassFrequency	KEYWORD2
+getEarSpeaker	KEYWORD2
+getMonoMode	KEYWORD2
+getDifferentialOutput	KEYWORD2
+getPlaySpeed	KEYWORD2
+getState	KEYWORD2
+getTrebleAmplitude	KEYWORD2
+getTrebleFrequency	KEYWORD2
+getVolume	KEYWORD2
+getVUlevel	KEYWORD2
+getVUmeter	KEYWORD2
+isFnMusic	KEYWORD2
+isPlaying	KEYWORD2
+memoryTest	KEYWORD2
+pauseDataStream	KEYWORD2
+pauseMusic	KEYWORD2
+playMP3	KEYWORD2
+playTrack	KEYWORD2
+resumeDataStream	KEYWORD2
+resumeMusic	KEYWORD2
+SendSingleMIDInote	KEYWORD2
+setBassAmplitude	KEYWORD2
+setBassFrequency	KEYWORD2
+setBitRate	KEYWORD2
+setEarSpeaker	KEYWORD2
+setMonoMode	KEYWORD2
+setDifferentialOutput	KEYWORD2
+setPlaySpeed	KEYWORD2
+setTrebleAmplitude	KEYWORD2
+setTrebleFrequency	KEYWORD2
+setVolume	KEYWORD2
+setVUmeter	KEYWORD2
+skip	KEYWORD2
+skipTo	KEYWORD2
+stopTrack	KEYWORD2
+trackAlbum	KEYWORD2
+trackArtist	KEYWORD2
+trackTitle	KEYWORD2
+vs_init	KEYWORD2
 
 
 #######################################
@@ -69,4 +69,4 @@ vs_init                  KEYWORD2
 #######################################
 # Instances (KEYWORD3)
 #######################################
-MP3player                KEYWORD3
+MP3player	KEYWORD3


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords